### PR TITLE
biicode automatic cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+IF(BIICODE)
+	ADD_BII_TARGETS()
+	return()
+endif()
+
 cmake_minimum_required(VERSION 3.1)
 
 project(w3-patch-downloader)

--- a/biicode.conf
+++ b/biicode.conf
@@ -26,7 +26,7 @@
 
 [tests]
     # Manual adjust of files that define a CTest test
-    # test/* pattern to evaluate this test/ folder sources like tests
+    tests/*
 
 [hooks]
     # These are defined equal to [dependencies],files names matching bii*stage*hook.py

--- a/source/main2.cpp
+++ b/source/main2.cpp
@@ -1,0 +1,11 @@
+#include <zlib/zlib/zlib.h>
+//#include <curl/curl.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    printf("Bye world");
+    
+    return 0;
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,11 @@
+#include <zlib/zlib/zlib.h>
+//#include <curl/curl.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    printf("Hello world");
+    
+    return 0;
+}

--- a/tests/main2.cpp
+++ b/tests/main2.cpp
@@ -1,0 +1,11 @@
+#include <zlib/zlib/zlib.h>
+//#include <curl/curl.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    printf("Bye world");
+    
+    return 0;
+}


### PR DESCRIPTION
Hi!

I suggest the following edit: If you are not using the biicode cmake macros, you are not using lot of biicode functionality. Note that with the suggested edit:

```
IF(BIICODE)
    ADD_BII_TARGETS()
    return()
endif()
```

all the remaining cmake files are just not used by biicode. It is able to deduce which targets to build, run tests... I have added several source files just as an example. Try to build:

```
$ bii build
```

And check what is being built. Tests are not

Now run:

```
$ bii test
```

The unit tests should be built and run. In this way, you dont have to specify linkage to your dependencies, it is automatically done. Please have a look and tell me what you think :). Cheers
